### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM jmaupetit/md2pdf:latest
+
+RUN rm -rf ~/clermontech-moucss && git clone https://github.com/clermontech/Clermontech-MouCSS.git ~/clermontech-moucss
+
+RUN cp ~/clermontech-moucss/fonts/* /usr/share/fonts/
+
+RUN fc-cache -f -v
+
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Clermont'ech
 
 Les documents officiels de l'association de développeurs clermontois.
+
+## Docker
+
+A dockerfile is present if you want to use [md2pdf](https://github.com/jmaupetit/md2pdf) to generate the documents. This container contains all needed fonts.
+
+### Usage
+
+Build the image
+
+```
+$ docker build -t clermontech-md2pdf .
+```
+
+Then use it
+
+```
+$ docker run -t -i -v $PWD:/srv clermontech-md2pdf INPUT.md OUTPUT.pdf --css=FILE.css
+```


### PR DESCRIPTION
Rajout du dockerfile qui installe les fonts dont on a besoin pour générer les documents.

Le mieux serait de créer un compte clermontech sur le hub de docker, sur lequel on push notr image. Ainsi pas besoin de la créer quand on en a besoin, on fait un pull et on l'utilise.
